### PR TITLE
Replace OK with DUNNO response for non-send-only mailboxes

### DIFF
--- a/source/postfix-and-dovecot.blade.md
+++ b/source/postfix-and-dovecot.blade.md
@@ -76,7 +76,7 @@ user = mum_postfix_user
 password = mum_postfix_password
 hosts = 127.0.0.1
 dbname = mum_database
-query = SELECT IF(send_only = 1, 'REJECT', 'OK') AS access FROM mailboxes INNER JOIN domains ON mailboxes.domain_id = domains.id WHERE mailboxes.local_part = '%u' AND domains.domain = '%d' AND domains.active = 1 AND mailboxes.active = 1 LIMIT 1;
+query = SELECT IF(send_only = 1, 'REJECT', 'DUNNO') AS access FROM mailboxes INNER JOIN domains ON mailboxes.domain_id = domains.id WHERE mailboxes.local_part = '%u' AND domains.domain = '%d' AND domains.active = 1 AND mailboxes.active = 1 LIMIT 1;
 @endcomponent
 
 ### Sender Login Maps

--- a/source/postfix-and-dovecot.blade.md
+++ b/source/postfix-and-dovecot.blade.md
@@ -20,7 +20,19 @@ all MySQL lookup files.
     @slot('filename', '/etc/postfix/main.cf')
 smtp_tls_policy_maps = mysql:/etc/postfix/sql/tls-policies.cf
 ...
-smtpd_recipient_restrictions = check_recipient_access mysql:/etc/postfix/sql/recipient-access.cf
+smtpd_recipient_restrictions = 
+    reject_non_fqdn_sender,   
+    reject_non_fqdn_recipient,   
+    reject_unknown_sender_domain,   
+    reject_unknown_recipient_domain,
+    reject_invalid_hostname,
+    warn_if_reject reject_unauth_pipelining,
+    check_recipient_access mysql:/etc/postfix/sql/recipient-access.cf,
+    permit_sasl_authenticated,
+    permit_mynetworks,
+    reject_unverified_recipient,
+    reject_unauth_destination,
+    permit
 ...
 virtual_alias_maps = mysql:/etc/postfix/sql/aliases.cf
 virtual_mailbox_maps = mysql:/etc/postfix/sql/mailboxes.cf


### PR DESCRIPTION
Since MUM's lookup table for Postfix's `check_recipient_access` directive may be used in a blacklisting approach like below, we should not mark an email as OK when the mailbox purely exists.

For example, when using the `recipient-access.cf` lookup file in the middle of multiple restrictions, we **don't** want to permit the email until we went down the list completely.

```ini
smtpd_recipient_restrictions =
# Recipient whitelisting
        check_recipient_access btree:/etc/postfix/lookup/access_recipient,
# Host/sender blacklisting
        check_client_access cidr:/etc/postfix/lookup/access_client, 
        check_helo_access btree:/etc/postfix/lookup/access_helo,  
        check_sender_access btree:/etc/postfix/lookup/access_sender,
# Reject invalid emails
        reject_non_fqdn_sender,   
        reject_non_fqdn_recipient,   
        reject_unknown_sender_domain,   
        reject_unknown_recipient_domain,
        reject_invalid_hostname,
# Prohibit unauthenticated pipelining
	warn_if_reject reject_unauth_pipelining,
# Prohibit send-only mailboxes from receiving mail
        check_recipient_access mysql:/etc/postfix/sql/recipient-access.cf,
# Allow authenticated clients
        permit_sasl_authenticated,
        permit_mynetworks,
# Verify recipient
	reject_unverified_recipient,
# Accept mail as backup MX
#        permit_mx_backup,
# Prohibit relaying (we don't want to be an open relay)
        reject_unauth_destination,
# Check quota status of recipient with Dovecot
        check_policy_service inet:localhost:12340,
# Accept everything that passed the steps above
        permit
```